### PR TITLE
Fix URL encoding bug from e78cc69d

### DIFF
--- a/venmo-sdk/Categories/NSURL+VenmoSDK.m
+++ b/venmo-sdk/Categories/NSURL+VenmoSDK.m
@@ -9,7 +9,7 @@
 
 + (NSURL *)venmoAppURLWithPath:(NSString *)path {
     NSString *newPath = [NSString stringWithFormat:@"venmosdk://venmo.com%@", path];
-    return [[NSURL alloc] initWithString:[newPath stringByRemovingPercentEncoding]];
+    return [[NSURL alloc] initWithString:[newPath stringByAddingPercentEncodingWithAllowedCharacters:[NSCharacterSet URLQueryAllowedCharacterSet]]];
 }
 
 @end


### PR DESCRIPTION
See [here](https://github.com/splitwise/venmo-ios-sdk/commit/e78cc69d3eb20d1f40739880eee9660c2d5efb79#diff-b7442e648e69a7fff1496adf655bf327L12) for the original issue – we accidentally went from adding percent encoding to removing it, which broke our Venmo integration. Once this is fixed, we'll need  to update the pod on the splitwise-iphone repo.

/cc @mgod @novall